### PR TITLE
Add download progress bar feature

### DIFF
--- a/animesaturn_downloader.py
+++ b/animesaturn_downloader.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 import re
 import os
 from requests_html import HTMLSession
+from alive_progress import alive_bar
 import traceback
 import time
 
@@ -115,9 +116,10 @@ def main(main_url: str, ep_range_start: int, ep_range_end: int):
       with open(ep_name_tmp, "wb") as output_buffer:
         n_parts = len(playlist_urls)
         logging.info(f"Found {n_parts} parts")
-        for i, pu in enumerate(playlist_urls):
-          logging.info(f"Downloading part {i+1} of {n_parts}")
-          output_buffer.write(download_resource(pu))
+        with alive_bar(n_parts) as bar:
+          for i, pu in enumerate(playlist_urls):
+            output_buffer.write(download_resource(pu))
+            bar()
       os.rename(ep_name_tmp, ep_name_dest + ".ts")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.10.0
 progress==1.6
 requests==2.26.0
 requests_html==0.10.0
+alive-progress==2.3


### PR DESCRIPTION
## Update
instead of showing the usual cascade of downloaded parts now the script will show an elegant progress bar. 
### Note
To make things work, this update also changes the `requirments.txt` so that alive_progress bar dependencies can be installed